### PR TITLE
refactor(nginx): 移除代理缓冲区大小设置

### DIFF
--- a/nginx/proxy_params_file.conf
+++ b/nginx/proxy_params_file.conf
@@ -6,4 +6,3 @@ proxy_read_timeout 600s;
 proxy_send_timeout 600s;
 gzip off; # 禁用压缩，避免大文件开销
 proxy_buffering off;
-proxy_buffer_size 128k;


### PR DESCRIPTION
-从 proxy_params_file.conf 文件中删除了 proxy_buffer_size 指令
- 此更改旨在简化配置并依赖于 Nginx 的默认缓冲区大小设置