### PR TITLE
feat(nginx): 为 nginx配置添加 Docker 内部的DNS 解析服务器

### DIFF
--- a/nginx/nginx.conf.no_office.template
+++ b/nginx/nginx.conf.no_office.template
@@ -16,7 +16,7 @@ http {
     include mime.types;
     default_type application/octet-stream;
 
-    resolver 127.0.0.11 valid=30s;
+    resolver 127.0.0.11 valid=30s ipv6=off;
 
     # 日志
     #access_log /var/log/nginx/access.log main buffer=32k flush=5s;

--- a/nginx/nginx.conf.no_office.template
+++ b/nginx/nginx.conf.no_office.template
@@ -16,6 +16,8 @@ http {
     include mime.types;
     default_type application/octet-stream;
 
+    resolver 127.0.0.11 valid=30s;
+
     # 日志
     #access_log /var/log/nginx/access.log main buffer=32k flush=5s;
     access_log off;

--- a/nginx/nginx.conf.template
+++ b/nginx/nginx.conf.template
@@ -16,7 +16,7 @@ http {
     include mime.types;
     default_type application/octet-stream;
 
-    resolver 127.0.0.11 valid=30s;
+    resolver 127.0.0.11 valid=30s ipv6=off;
 
     # 日志
     #access_log /var/log/nginx/access.log main buffer=32k flush=5s;

--- a/nginx/nginx.conf.template
+++ b/nginx/nginx.conf.template
@@ -16,6 +16,8 @@ http {
     include mime.types;
     default_type application/octet-stream;
 
+    resolver 127.0.0.11 valid=30s;
+
     # 日志
     #access_log /var/log/nginx/access.log main buffer=32k flush=5s;
     access_log off;


### PR DESCRIPTION
- 在 nginx.conf.template 和… nginx.conf.no_office.template 文件中添加了 resolver 配置

- 设置 DNS服务器为 127.0.0.11，缓存时间为 30 秒