### PR TITLE
fit: 修复网络延迟导致`uploaderChunkSize`未收到前默认使用S3模式的问题

### DIFF
--- a/src/components/SimpleUploader/globalUploader.vue
+++ b/src/components/SimpleUploader/globalUploader.vue
@@ -202,7 +202,7 @@ export default {
       resolveFilesAddedPromise: null, // 用于等待获取上传参数
       params: {},
       // S3直传相关
-      useS3Direct: true, // 是否启用S3直传模式
+      useS3Direct: null, // 是否启用S3直传模式，未收到uploaderChunkSize前不确定
       s3Uploader: null,
     }
   },
@@ -491,7 +491,7 @@ export default {
     async doFilesAdded(files) {
       let filenames = files.map(file => file.name)
       const paths = Object.keys(this.uploader.filePaths)
-      if (paths.length > 0 && this.useS3Direct) {
+      if (paths.length > 0 && true == this.useS3Direct) {
         // 暂不支持文件夹上传
         this.$message({
           message: 'S3直传模式下暂不支持文件夹上传',
@@ -567,7 +567,7 @@ export default {
       }
 
       // 判断是否使用S3直传
-      if (this.useS3Direct) {
+      if (true == this.useS3Direct) {
         // 使用S3直传模式
         await this.doS3DirectUpload();
       } else {


### PR DESCRIPTION
接触这个项目的时间只有不到24h，尚不太了解，经过调试，比对正常运行和nginx托管的f12网络请求，发现选择文件后，正常是调用了`/api/upload`，而使用nginx托管的服务却调用了`/api/oss/presign/upload`，于是后端响应
```
{
  "code": -2,
  "message": "无法获取文件的OSS存储路径"
}
```
阅读相关代码发现

```
通过阅读 `src/components/SimpleUploader/globalUploader.vue` 的 `data()` 部分，可以看到这个变量的**初始值是 `true`**：
```javascript
data() {
  return {
    // ... 其他属性
    useS3Direct: true, 
    // ... 其他属性
  }
}
```

搜索改变`useS3Direct`的相关代码，发现是一个`uploaderChunkSize`事件，比对前端的请求发现了一个sse请求，nginx托管的这个没有一行消息，正常的那个有包含ChunkSize的消息。自此真相大白。

实际上是没有将nginx的`proxy_buffering`设置为`off`导致ChunkSize的sse消息一直没有达到buffer阈值而没有发到前端，而代码默认的useS3Direct为true，导致了问题。

虽然这个情况是缺少`proxy_buffering off`导致的，但现实中仍有网络延迟等因素导致在用户添加文件或上传前未能收到这条ChunkSize消息。

---

使用`useS3Direct: null`而不是`useS3Direct: false`是为了从语义上表明不确定是否使用S3模式，由于某些情况下更常用非S3模式，故在后续判断中使用`true == useS3Direct`确保只有当`useS3Direct`明确为`true`时才使用S3模式，默认使用不使用S3模式

也可以在添加文件时判断`useS3Direct`是否为`null`，若是则显示一个提示框供用户手动选择

总之此处默认不使用S3应该是更合理的做法